### PR TITLE
Make initial regexp customizable.

### DIFF
--- a/ialign.el
+++ b/ialign.el
@@ -83,6 +83,11 @@ or equal to this, otherwise do not update."
 	   (const :tag "Always update" t)
 	   (integer :tag "Update if number of lines is less than or equal")))
 
+(defcustom ialign-initial-regexp "\\(\\s-+\\)"
+  "Initial regexp to use when calling `ialign-interactive-align'."
+  :group 'ialign
+  :type 'regexp)
+
 (defvar ialign--buffer nil)
 (defvar ialign--start nil)
 (defvar ialign--end nil)
@@ -320,7 +325,8 @@ The keymap used in minibuffer is `ialign-minibuffer-keymap':
 	  (progn
 	    (add-hook 'after-change-functions #'ialign--after-change)
 	    (let ((buffer-undo-list t))
-	      (read-from-minibuffer " " "\\(\\s-+\\)" ialign-minibuffer-keymap
+	      (read-from-minibuffer " " ialign-initial-regexp
+                                    ialign-minibuffer-keymap
 				    nil 'ialign--history)
 	      (setq success t)))
 	(if success


### PR DESCRIPTION
## problem
When separators are different than space(s), initial regexp (when calling `ialign-interaction-align`) has to be modified each time.

## Solution 
This PR makes the default initial regexp customizable, so you can use `\\([[:blank:]]+\\)` for mix of tab and space for example.